### PR TITLE
Proposal for bug in issue #219 - app crashes if user logs in manually …

### DIFF
--- a/app/src/main/java/com/example/unserhoersaal/Config.java
+++ b/app/src/main/java/com/example/unserhoersaal/Config.java
@@ -166,6 +166,8 @@ public class Config {
           "Verifizierungsemail versandt";
   public static final String AUTH_VERIFICATION_EMAIL_NOT_SENT =
           "Die Verfizierungsemail konnte nicht versandt werden!";
+  public static final String AUTH_VERIFICATION_TOO_MANY_REQUESTS =
+          "Von deinem Gerät wurde zu viele Anfragen registriert. Versuch es später erneut!";
   public static final String AUTH_PASSWORD_RESET_MAIL_SENT =
           "Email zur Passwortzurücksetzung versandt.";
   public static final String AUTH_PASSWORD_RESET_MAIL_NOT_SENT =

--- a/app/src/main/java/com/example/unserhoersaal/viewmodel/LoginViewModel.java
+++ b/app/src/main/java/com/example/unserhoersaal/viewmodel/LoginViewModel.java
@@ -137,38 +137,13 @@ public class LoginViewModel extends ViewModel {
 
   /** Resend email verification email. Requires a logged in user! Cant send an email without
    * the user being logged in! */
-  public void resendVerificationEmail() {
+  public void sendVerificationEmail() {
     this.userLiveData.postLoading();
-    this.authAppRepository.resendVerificationEmail();
+    this.authAppRepository.sendVerificationEmail();
   }
 
-  /** Changes the password of the user. */
-  public void resetPassword() {
-    UserModel userModel = Validation.checkStateLiveData(this.userInputState, TAG);
-    if (userModel == null) {
-      Log.e(TAG, "userModel is null.");
-      this.userInputState.postError(new Error(Config.UNSPECIFIC_ERROR), ErrorTag.VM);
-      return;
-    }
-
-    String email = userModel.getEmail();
-
-    if (Validation.emptyString(email)) {
-      Log.d(TAG, "email is null.");
-      this.userInputState.postError(new Error(Config.AUTH_EMAIL_EMPTY), ErrorTag.EMAIL);
-    } else if (!Validation.emailHasPattern(email)) {
-      Log.d(TAG, "email has wrong pattern.");
-      this.userInputState.postError(
-              new Error(Config.AUTH_EMAIL_WRONG_PATTERN_LOGIN), ErrorTag.EMAIL);
-    } else {
-
-      this.setDefaultInputState();
-      this.authAppRepository.resetPassword(email);
-    }
-  }
-
-  public void reloadFirebaseUser() {
-    this.authAppRepository.reloadFirebaseUser();
+  public void isUserEmailVerified() {
+    this.authAppRepository.isUserEmailVerified();
   }
 
   public void logout() {

--- a/app/src/main/java/com/example/unserhoersaal/views/LoginFragment.java
+++ b/app/src/main/java/com/example/unserhoersaal/views/LoginFragment.java
@@ -113,8 +113,11 @@ public class LoginFragment extends Fragment {
               && deepLinkMode.getDeepLinkMode() == DeepLinkEnum.ENTER_COURSE) {
         navController.navigate(R.id.action_loginFragment_to_enterCourseFragment);
       } else if (firebaseUser.isEmailVerified()) {
+        Log.d(TAG, "LF: redirecting to course fragment");
         navController.navigate(R.id.action_loginFragment_to_coursesFragment);
       } else if (!firebaseUser.isEmailVerified()) {
+        Log.d(TAG, "LF: redirecting to verificication fragment");
+        loginViewModel.sendVerificationEmail();
         navController.navigate(R.id.action_loginFragment_to_verificationFragment);
       }
     } else if (firebaseUserStateData.getStatus() == StateData.DataStatus.LOADING) {

--- a/app/src/main/java/com/example/unserhoersaal/views/VerificationFragment.java
+++ b/app/src/main/java/com/example/unserhoersaal/views/VerificationFragment.java
@@ -7,6 +7,8 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
@@ -62,13 +64,12 @@ public class VerificationFragment extends Fragment {
    * into the application. */
   private void emailVerifiedChecker() {
     this.handler = new Handler();
-    this.handler.postDelayed(this.runnable, Config.VERIFICATION_EMAIL_VERIFIED_CHECK_INTERVAL);
     this.runnable = () -> {
       Log.d(TAG, "checking for authstatechange");
-      loginViewModel.reloadFirebaseUser();
+      loginViewModel.isUserEmailVerified();
       handler.postDelayed(this.runnable, Config.VERIFICATION_EMAIL_VERIFIED_CHECK_INTERVAL);
     };
-    this.handler.post(this.runnable);
+    this.handler.postDelayed(this.runnable, Config.VERIFICATION_EMAIL_VERIFIED_CHECK_INTERVAL);
   }
 
   private void initViewModel() {
@@ -96,14 +97,17 @@ public class VerificationFragment extends Fragment {
       this.binding.verificationFragmentErrorText
               .setText(firebaseUserStateData.getError().getMessage());
       this.binding.verificationFragmentErrorText.setVisibility(View.VISIBLE);
-    } else {
+    } else if (firebaseUserStateData.getStatus() == StateData.DataStatus.UPDATE) {
       FirebaseUser firebaseUser = firebaseUserStateData.getData();
 
       if (firebaseUser == null) {
-        Log.d(TAG, "firebase user is null");
+        Log.d(TAG, "VF: firebase user is null -> login");
         navController.navigate(R.id.action_verificationFragment_to_loginFragment);
       } else if (firebaseUser.isEmailVerified()) {
+        Log.d(TAG, "VF: redirecting to course fragment");
         navController.navigate(R.id.action_verificationFragment_to_coursesFragment);
+      } else {
+        Toast.makeText(getContext(), Config.AUTH_VERIFICATION_EMAIL_SENT, Toast.LENGTH_SHORT).show();
       }
     }
   }

--- a/app/src/main/res/layout/fragment_verification.xml
+++ b/app/src/main/res/layout/fragment_verification.xml
@@ -48,10 +48,12 @@
 
         <TextView
             android:id="@+id/verificationFragmentErrorText"
+            android:layout_marginTop="32dp"
+            android:layout_marginStart="54dp"
+            android:layout_marginEnd="54dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textColor="@color/red"
-            android:textAlignment="center"
             android:visibility="gone"/>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -64,10 +66,9 @@
                     android:id="@+id/verificationFragmentResendEmailButton"
                     android:layout_width="300dp"
                     android:layout_height="wrap_content"
-                    android:onClick="@{() -> vm.resendVerificationEmail()}"
+                    android:onClick="@{() -> vm.sendVerificationEmail()}"
                     android:text="@string/send_again"
                     android:layout_gravity="center"
-                    android:layout_marginTop="32dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
…after verification

removed adding authstatelistener in VerificationFragment related methods in LoginViewModel and AuthAppRepository
removed authstatelistener from AuthAppRepository
added simple check in AuthAppRepository where FirebaseAuth is reloaded and checked if email is verified now
added a toast message in VerificationFragment when email was sent
added error messages in VerificationFragment if user makes too many requests
merged resendverificationemail and sendverificationemail in LoginViewModel and AuthAppRepository
removed resetpassword methods in LoginViewModel and AuthAppRepository because it is in profile related files
minor change in verification_fragment.xml to align error text and have less space between first button and text above
calling sendverificationemail when user logs in manually

modified:   app/src/main/java/com/example/unserhoersaal/Config.java
modified:   app/src/main/java/com/example/unserhoersaal/repository/AuthAppRepository.java
modified:   app/src/main/java/com/example/unserhoersaal/viewmodel/LoginViewModel.java
modified:   app/src/main/java/com/example/unserhoersaal/views/LoginFragment.java
modified:   app/src/main/java/com/example/unserhoersaal/views/VerificationFragment.java
modified:   app/src/main/res/layout/fragment_verification.xml