### PR TITLE
#230 Simultaneous filtering using multiple filter options

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -126,6 +126,7 @@
         <entry key="..\:/Users/Ruslan/Documents/GitHub/ase-ws-21-unser-horsaal/app/src/main/res/layout/fragment_dialog_email_verification.xml" value="0.21557971014492755" />
         <entry key="..\:/Users/Ruslan/Documents/GitHub/ase-ws-21-unser-horsaal/app/src/main/res/layout/fragment_login.xml" value="0.1" />
         <entry key="..\:/Users/Ruslan/Documents/GitHub/ase-ws-21-unser-horsaal/app/src/main/res/layout/fragment_profile.xml" value="0.21557971014492755" />
+        <entry key="..\:/Users/Ruslan/Documents/GitHub/ase-ws-21-unser-horsaal/app/src/main/res/layout/fragment_questions.xml" value="0.1" />
         <entry key="..\:/Users/Ruslan/Documents/GitHub/ase-ws-21-unser-horsaal/app/src/main/res/layout/fragment_registration.xml" value="0.1" />
         <entry key="..\:/Users/Ruslan/Documents/GitHub/ase-ws-21-unser-horsaal/app/src/main/res/layout/fragment_reset_password.xml" value="0.1" />
         <entry key="..\:/Users/Ruslan/Documents/GitHub/ase-ws-21-unser-horsaal/app/src/main/res/layout/thread_item.xml" value="0.1" />

--- a/app/src/main/java/com/example/unserhoersaal/enums/FilterEnum.java
+++ b/app/src/main/java/com/example/unserhoersaal/enums/FilterEnum.java
@@ -7,6 +7,7 @@ public enum FilterEnum {
   UNSOLVED,
   OWN,
   CREATOR,
+  LECTURE_PERIOD,
   SUBJECT_MATTER,
   ORGANISATION,
   MISTAKE,

--- a/app/src/main/java/com/example/unserhoersaal/enums/FilterEnum.java
+++ b/app/src/main/java/com/example/unserhoersaal/enums/FilterEnum.java
@@ -2,6 +2,7 @@ package com.example.unserhoersaal.enums;
 
 public enum FilterEnum {
   NONE,
+  RESET,
   SOLVED,
   UNSOLVED,
   OWN,

--- a/app/src/main/java/com/example/unserhoersaal/utils/ArrayListUtil.java
+++ b/app/src/main/java/com/example/unserhoersaal/utils/ArrayListUtil.java
@@ -10,7 +10,9 @@ import com.example.unserhoersaal.model.MessageModel;
 import com.example.unserhoersaal.model.ThreadModel;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ArrayListUtil {
 
@@ -57,8 +59,8 @@ public class ArrayListUtil {
   /** Filter options for ThreadModel lists. */
   public void filterThreadList(List<ThreadModel> threadsModelList,
                                StateLiveData<List<ThreadModel>> outFilteredThreads,
-                               FilterEnum filterOption, MeetingsModel currentMeeting,
-                               String userId) {
+                               FilterEnum filterOption, ArrayList<FilterEnum> enumArray,
+                               MeetingsModel currentMeeting, String userId) {
 
     switch (filterOption) {
       case SOLVED:
@@ -89,7 +91,10 @@ public class ArrayListUtil {
         filterThreadListByTag(threadsModelList, TagEnum.OTHER, outFilteredThreads);
         break;
       case NONE:
-        resetThreadList(threadsModelList, outFilteredThreads);
+        resetThreadList(threadsModelList, outFilteredThreads, enumArray, currentMeeting, userId);
+        break;
+      case RESET:
+        refreshList(threadsModelList, outFilteredThreads);
         break;
     }
   }
@@ -174,9 +179,7 @@ public class ArrayListUtil {
   private void filterThreadListByAnswerStatus(List<ThreadModel> threadsModelList,
                                               Boolean answered,
                                               StateLiveData<List<ThreadModel>> outFilteredThreads) {
-    if (outFilteredThreads.getValue() != null) {
-      threadsModelList.addAll(outFilteredThreads.getValue().getData());
-    }
+
     List<ThreadModel> filteredList = new ArrayList<>();
     List<ThreadModel> outFilteredList = new ArrayList<>();
       for (int i = 0; i < threadsModelList.size(); i++) {
@@ -188,7 +191,15 @@ public class ArrayListUtil {
       }
     threadsModelList.clear();
     threadsModelList.addAll(filteredList);
-    outFilteredThreads.postUpdate(outFilteredList);
+
+    if (outFilteredThreads.getValue() != null) {
+      Set<ThreadModel> threadsListAsSet = new HashSet<>(outFilteredThreads.getValue().getData());
+      threadsListAsSet.addAll(outFilteredList);
+      List<ThreadModel> fullList = new ArrayList<>(threadsListAsSet);
+      outFilteredThreads.postUpdate(fullList);
+    } else {
+      outFilteredThreads.postUpdate(outFilteredList);
+    }
   }
 
   /** Filter threads and just show threads created by the course provider. */
@@ -196,9 +207,6 @@ public class ArrayListUtil {
                                                 MeetingsModel currentMeeting,
                                                 StateLiveData<List<ThreadModel>> outFilteredThreads)
   {
-    if (outFilteredThreads.getValue() != null) {
-      threadsModelList.addAll(outFilteredThreads.getValue().getData());
-    }
     List<ThreadModel> filteredList = new ArrayList<>();
     List<ThreadModel> outFilteredList = new ArrayList<>();
     for (int i = 0; i < threadsModelList.size(); i++) {
@@ -210,16 +218,22 @@ public class ArrayListUtil {
     }
     threadsModelList.clear();
     threadsModelList.addAll(filteredList);
-    outFilteredThreads.postUpdate(outFilteredList);
+
+    if (outFilteredThreads.getValue() != null) {
+      Set<ThreadModel> threadsListAsSet = new HashSet<>(outFilteredThreads.getValue().getData());
+      threadsListAsSet.addAll(outFilteredList);
+      List<ThreadModel> fullList = new ArrayList<>(threadsListAsSet);
+      outFilteredThreads.postUpdate(fullList);
+    } else {
+      outFilteredThreads.postUpdate(outFilteredList);
+    }
   }
 
   /** Filter threads and just show threads created by the current user. */
   private void filterThreadListByOwnThreads(List<ThreadModel> threadsModelList,
                                             String userId,
                                             StateLiveData<List<ThreadModel>> outFilteredThreads) {
-    if (outFilteredThreads.getValue() != null) {
-      threadsModelList.addAll(outFilteredThreads.getValue().getData());
-    }
+
     List<ThreadModel> filteredList = new ArrayList<>();
     List<ThreadModel> outFilteredList = new ArrayList<>();
     for (int i = 0; i < threadsModelList.size(); i++) {
@@ -231,15 +245,20 @@ public class ArrayListUtil {
     }
     threadsModelList.clear();
     threadsModelList.addAll(filteredList);
-    outFilteredThreads.postUpdate(outFilteredList);
+
+    if (outFilteredThreads.getValue() != null) {
+      Set<ThreadModel> threadsListAsSet = new HashSet<>(outFilteredThreads.getValue().getData());
+      threadsListAsSet.addAll(outFilteredList);
+      List<ThreadModel> fullList = new ArrayList<>(threadsListAsSet);
+      outFilteredThreads.postUpdate(fullList);
+    } else {
+      outFilteredThreads.postUpdate(outFilteredList);
+    }
   }
 
   /** Filter threads by tag. */
   private void filterThreadListByTag(List<ThreadModel> threadsModelList, TagEnum tagEnum,
                                      StateLiveData<List<ThreadModel>> outFilteredThreads) {
-    if (outFilteredThreads.getValue() != null) {
-      threadsModelList.addAll(outFilteredThreads.getValue().getData());
-    }
     List<ThreadModel> filteredList = new ArrayList<>();
     List<ThreadModel> outFilteredList = new ArrayList<>();
     for (int i = 0; i < threadsModelList.size(); i++) {
@@ -252,15 +271,57 @@ public class ArrayListUtil {
       }
     threadsModelList.clear();
     threadsModelList.addAll(filteredList);
-    outFilteredThreads.postUpdate(outFilteredList);
+
+    if (outFilteredThreads.getValue() != null) {
+      Set<ThreadModel> threadsListAsSet = new HashSet<>(outFilteredThreads.getValue().getData());
+      threadsListAsSet.addAll(outFilteredList);
+      List<ThreadModel> fullList = new ArrayList<>(threadsListAsSet);
+      outFilteredThreads.postUpdate(fullList);
+    } else {
+      outFilteredThreads.postUpdate(outFilteredList);
     }
+  }
 
   /** Reset filter/show all threads */
-  private void resetThreadList(List<ThreadModel> threadModelList,
-                               StateLiveData<List<ThreadModel>> outFilteredThreads) {
+  private void resetThreadList(List<ThreadModel> threadsModelList,
+                               StateLiveData<List<ThreadModel>> outFilteredThreads,
+                               ArrayList<FilterEnum> enumArray, MeetingsModel currentMeeting,
+                               String userId) {
     if (outFilteredThreads.getValue() != null) {
-      threadModelList.addAll(outFilteredThreads.getValue().getData());
+      Set<ThreadModel> threadsModelListAsSet = new HashSet<>(threadsModelList);
+      threadsModelListAsSet.addAll(outFilteredThreads.getValue().getData());
+      List<ThreadModel> fullThreadList = new ArrayList<>(threadsModelListAsSet);
+      threadsModelList.clear();
+      threadsModelList.addAll(fullThreadList);
     }
-    outFilteredThreads.postUpdate(new ArrayList<>());
+    if (enumArray.contains(FilterEnum.CREATOR)) {
+      filterThreadListByCourseProvider(threadsModelList, currentMeeting, outFilteredThreads);
+    } else if (enumArray.contains(FilterEnum.OWN)) {
+      filterThreadListByOwnThreads(threadsModelList, userId, outFilteredThreads);
+    } else if (enumArray.contains(FilterEnum.SOLVED)) {
+      filterThreadListByAnswerStatus(threadsModelList, true, outFilteredThreads);
+    } else if (enumArray.contains(FilterEnum.UNSOLVED)) {
+      filterThreadListByAnswerStatus(threadsModelList, false, outFilteredThreads);
+    } else if (enumArray.contains(FilterEnum.SUBJECT_MATTER)) {
+      filterThreadListByTag(threadsModelList, TagEnum.SUBJECT_MATTER,  outFilteredThreads);
+    } else if (enumArray.contains(FilterEnum.ORGANISATION)) {
+      filterThreadListByTag(threadsModelList, TagEnum.ORGANISATION,  outFilteredThreads);
+    } else if (enumArray.contains(FilterEnum.EXAMINATION)) {
+      filterThreadListByTag(threadsModelList, TagEnum.EXAMINATION,  outFilteredThreads);
+    } else if (enumArray.contains(FilterEnum.MISTAKE)) {
+      filterThreadListByTag(threadsModelList, TagEnum.MISTAKE,  outFilteredThreads);
+    } else if (enumArray.contains(FilterEnum.OTHER)) {
+      filterThreadListByTag(threadsModelList, TagEnum.OTHER,  outFilteredThreads);
+    }
+  }
+
+  private void refreshList(List<ThreadModel> threadsModelList, StateLiveData<List<ThreadModel>> outFilteredThreads) {
+    Set<ThreadModel> threadsModelListAsSet = new HashSet<>(threadsModelList);
+    List<ThreadModel> fullThreadList = new ArrayList<>(threadsModelListAsSet);
+    threadsModelList.clear();
+    threadsModelList.addAll(fullThreadList);
+    if (outFilteredThreads.getValue() != null) {
+      outFilteredThreads.getValue().getData().clear();
+    }
   }
 }

--- a/app/src/main/java/com/example/unserhoersaal/utils/ArrayListUtil.java
+++ b/app/src/main/java/com/example/unserhoersaal/utils/ArrayListUtil.java
@@ -22,19 +22,6 @@ public class ArrayListUtil {
    * Used to sort and filter meetings, threads and answers by various parameters.
    */
 
-  /** Sorting options for MeetingsModel lists. */
-  public void sortMeetingList(List<MeetingsModel> meetingsModelList, String sortingOption) {
-
-    switch (sortingOption) {
-      case "newest":
-        sortMeetingListByEventTime(meetingsModelList, "descending");
-        break;
-      case "oldest":
-        sortMeetingListByEventTime(meetingsModelList, "ascending");
-        break;
-    }
-  }
-
   /** Sorting options for ThreadModel lists. */
   public void sortThreadList(List<ThreadModel> threadsModelList, SortEnum sortingOption) {
 
@@ -117,13 +104,10 @@ public class ArrayListUtil {
 
 
   /** Sort meetings by event time. */
-  private void sortMeetingListByEventTime(List<MeetingsModel> meetingsModelList, String order) {
+  public void sortMeetingListByEventTime(List<MeetingsModel> meetingsModelList) {
     meetingsModelList.sort(new Comparator<MeetingsModel>() {
       @Override
       public int compare(MeetingsModel meetingsModel, MeetingsModel t1) {
-        if (order.equals("ascending")) {
-          return meetingsModel.getEventTime().compareTo(t1.getEventTime());
-        }
         return t1.getEventTime().compareTo(meetingsModel.getEventTime());
       }
     });

--- a/app/src/main/java/com/example/unserhoersaal/utils/FilterSortUtil.java
+++ b/app/src/main/java/com/example/unserhoersaal/utils/FilterSortUtil.java
@@ -52,7 +52,7 @@ public class FilterSortUtil {
                                   FilterEnum filterEnum) {
     view.setChecked(Boolean.FALSE);
     chipActivated.setVisibility(View.GONE);
-    vm.setFilterEnum(FilterEnum.NONE);
+    vm.setFilterEnum(filterEnum);
   }
 
 }

--- a/app/src/main/java/com/example/unserhoersaal/viewmodel/CourseHistoryViewModel.java
+++ b/app/src/main/java/com/example/unserhoersaal/viewmodel/CourseHistoryViewModel.java
@@ -59,10 +59,9 @@ public class CourseHistoryViewModel extends ViewModel {
 
   /** Sort the meetings list.
    * @param meetingsModelList list of meetingmodels to filter
-   * @param sortOption ("newest" and "oldest")
    */
-  public void sortMeetings(List<MeetingsModel> meetingsModelList, String sortOption) {
-   this.arrayListUtil.sortMeetingList(meetingsModelList, sortOption);
+  public void sortMeetingsByNewest(List<MeetingsModel> meetingsModelList) {
+   this.arrayListUtil.sortMeetingListByEventTime(meetingsModelList);
   }
 
   public StateLiveData<CourseModel> getCourse() {

--- a/app/src/main/java/com/example/unserhoersaal/viewmodel/QuestionsViewModel.java
+++ b/app/src/main/java/com/example/unserhoersaal/viewmodel/QuestionsViewModel.java
@@ -15,7 +15,9 @@ import com.example.unserhoersaal.utils.StateLiveData;
 import com.example.unserhoersaal.utils.Validation;
 import com.google.firebase.auth.FirebaseUser;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /** ViewModel for the QuestionsFragment. */
 public class QuestionsViewModel extends ViewModel {
@@ -30,7 +32,8 @@ public class QuestionsViewModel extends ViewModel {
   private StateLiveData<List<ThreadModel>> outFilteredThreads = new StateLiveData<>();
   public StateLiveData<ThreadModel> threadModelInputState = new StateLiveData<>();
   private final StateLiveData<SortEnum> sortEnum = new StateLiveData<>();
-  private final StateLiveData<FilterEnum> filterEnum = new StateLiveData<>();
+  private StateLiveData<FilterEnum> filterEnum = new StateLiveData<>();
+  private ArrayList<FilterEnum> enumArray = new ArrayList<>();
   private ArrayListUtil arrayListUtil;
 
   /** Initialise the ViewModel. */
@@ -81,7 +84,7 @@ public class QuestionsViewModel extends ViewModel {
     MeetingsModel actualMeeting = Validation.checkStateLiveData(this.meeting, TAG);
     String userId = firebaseUser.getUid();
     this.arrayListUtil.filterThreadList(threadsModelList, outFilteredThreads,
-            filterEnum, actualMeeting, userId);
+            filterEnum, enumArray, actualMeeting, userId);
   }
 
   public StateLiveData<MeetingsModel> getMeeting() {
@@ -93,7 +96,19 @@ public class QuestionsViewModel extends ViewModel {
   }
 
   public void setFilterEnum(FilterEnum filterEnum) {
-    this.filterEnum.postUpdate(filterEnum);
+    if (!enumArray.contains(filterEnum)) {
+      this.enumArray.add(filterEnum);
+      this.filterEnum.postUpdate(filterEnum);
+    } else {
+      this.enumArray.remove(filterEnum);
+      this.filterEnum.postUpdate(FilterEnum.NONE);
+    }
+  }
+
+  public void resetFilters() {
+    this.enumArray.clear();
+    this.filterEnum.postUpdate(FilterEnum.NONE);
+    this.filterEnum.postUpdate(FilterEnum.RESET);
   }
 
   public StateLiveData<SortEnum> getSortEnum() {

--- a/app/src/main/java/com/example/unserhoersaal/views/CourseHistoryFragment.java
+++ b/app/src/main/java/com/example/unserhoersaal/views/CourseHistoryFragment.java
@@ -86,7 +86,7 @@ public class CourseHistoryFragment extends Fragment {
     }
     this.resetBindings();
     //sort meeting by newest
-    this.courseHistoryViewModel.sortMeetings(listStateData.getData(), "newest");
+    this.courseHistoryViewModel.sortMeetingsByNewest(listStateData.getData());
     this.meetingAdapter.notifyDataSetChanged();
 
     if (listStateData.getStatus() == StateData.DataStatus.LOADING) {

--- a/app/src/main/java/com/example/unserhoersaal/views/QuestionsFragment.java
+++ b/app/src/main/java/com/example/unserhoersaal/views/QuestionsFragment.java
@@ -142,6 +142,15 @@ public class QuestionsFragment extends Fragment {
   }
 
   private void filterEnumCallback(StateData<FilterEnum> filterEnum) {
+    if (filterEnum.getData() == FilterEnum.SOLVED) {
+      this.binding.questionChipUnanswered.setChecked(Boolean.FALSE);
+      this.binding.questionChipUnansweredActivated.setVisibility(View.GONE);
+    }
+    if (filterEnum.getData() == FilterEnum.UNSOLVED) {
+      this.binding.questionChipAnswered.setChecked(Boolean.FALSE);
+      this.binding.questionChipAnsweredActivated.setVisibility(View.GONE);
+    }
+
     this.questionsViewModel.getThreads().postUpdate(this.questionsViewModel
             .getThreads().getValue().getData());
   }

--- a/app/src/main/java/com/example/unserhoersaal/views/QuestionsFragment.java
+++ b/app/src/main/java/com/example/unserhoersaal/views/QuestionsFragment.java
@@ -21,7 +21,11 @@ import com.example.unserhoersaal.utils.KeyboardUtil;
 import com.example.unserhoersaal.utils.StateData;
 import com.example.unserhoersaal.viewmodel.CurrentCourseViewModel;
 import com.example.unserhoersaal.viewmodel.QuestionsViewModel;
+
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /** Displays the questions during the Meeting. */
 public class QuestionsFragment extends Fragment {
@@ -133,50 +137,11 @@ public class QuestionsFragment extends Fragment {
       this.binding.questionChipPageCountDownActivated.setVisibility(View.GONE);
     }
 
-    //TODO: is there a better solution to trigger the callback function for threads?
     this.questionsViewModel.getThreads().postUpdate(this.questionsViewModel.getThreads()
             .getValue().getData());
   }
 
   private void filterEnumCallback(StateData<FilterEnum> filterEnum) {
-    if (filterEnum.getData() != FilterEnum.SOLVED) {
-      this.binding.questionChipAnswered.setChecked(Boolean.FALSE);
-      this.binding.questionChipAnsweredActivated.setVisibility(View.GONE);
-    }
-    if (filterEnum.getData() != FilterEnum.UNSOLVED) {
-      this.binding.questionChipUnanswered.setChecked(Boolean.FALSE);
-      this.binding.questionChipUnansweredActivated.setVisibility(View.GONE);
-    }
-    if (filterEnum.getData() != FilterEnum.OWN) {
-      this.binding.questionChipOwn.setChecked(Boolean.FALSE);
-      this.binding.questionChipOwnActivated.setVisibility(View.GONE);
-    }
-    if (filterEnum.getData() != FilterEnum.CREATOR) {
-      this.binding.questionChipCreator.setChecked(Boolean.FALSE);
-      this.binding.questionChipCreatorActivated.setVisibility(View.GONE);
-    }
-    if (filterEnum.getData() != FilterEnum.SUBJECT_MATTER) {
-      this.binding.questionChipSubjectMatter.setChecked(Boolean.FALSE);
-      this.binding.questionChipSubjectMatterActivated.setVisibility(View.GONE);
-    }
-    if (filterEnum.getData() != FilterEnum.ORGANISATION) {
-      this.binding.questionChipOrganisation.setChecked(Boolean.FALSE);
-      this.binding.questionChipOrganisationActivated.setVisibility(View.GONE);
-    }
-    if (filterEnum.getData() != FilterEnum.MISTAKE) {
-      this.binding.questionChipMistake.setChecked(Boolean.FALSE);
-      this.binding.questionChipMistakeActivated.setVisibility(View.GONE);
-    }
-    if (filterEnum.getData() != FilterEnum.EXAMINATION) {
-      this.binding.questionChipExamination.setChecked(Boolean.FALSE);
-      this.binding.questionChipExaminationActivated.setVisibility(View.GONE);
-    }
-    if (filterEnum.getData() != FilterEnum.OTHER) {
-      this.binding.questionChipOther.setChecked(Boolean.FALSE);
-      this.binding.questionChipOtherActivated.setVisibility(View.GONE);
-    }
-
-    //TODO: is there a better solution to trigger the callback funtion for threads?
     this.questionsViewModel.getThreads().postUpdate(this.questionsViewModel
             .getThreads().getValue().getData());
   }
@@ -201,7 +166,12 @@ public class QuestionsFragment extends Fragment {
   public void onResume() {
     super.onResume();
     this.questionsViewModel.resetThreadModelInput();
-    this.questionsViewModel.setFilterEnum(FilterEnum.NONE);
     this.questionsViewModel.setSortEnum(SortEnum.NEWEST);
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    this.questionsViewModel.resetFilters();
   }
 }

--- a/app/src/main/res/layout/fragment_questions.xml
+++ b/app/src/main/res/layout/fragment_questions.xml
@@ -166,6 +166,14 @@
                         android:onClick="@{() -> FilterSortUtil.removeFilter(questionChipCreator, questionChipCreatorActivated, vm, FilterEnum.CREATOR)}"/>
 
                     <com.google.android.material.chip.Chip
+                        android:id="@+id/questionChipLecturePeriodActivated"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        android:text="@string/course_meeting_fragment_chip_lecture_period"
+                        android:onClick="@{() -> FilterSortUtil.removeFilter(questionChipLecturePeriod, questionChipLecturePeriodActivated, vm, FilterEnum.LECTURE_PERIOD)}"/>
+
+                    <com.google.android.material.chip.Chip
                         android:id="@+id/questionChipSubjectMatterActivated"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -339,6 +347,14 @@
                     android:checkable="true"
                     android:text="@string/course_meeting_fragment_chip_course_creator"
                     android:onClick="@{() -> FilterSortUtil.filter(questionChipCreator, questionChipCreatorActivated, vm, FilterEnum.CREATOR)}"/>
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/questionChipLecturePeriod"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:checkable="true"
+                    android:text="@string/course_meeting_fragment_chip_lecture_period"
+                    android:onClick="@{() -> FilterSortUtil.filter(questionChipLecturePeriod, questionChipLecturePeriodActivated, vm, FilterEnum.LECTURE_PERIOD)}"/>
 
             </com.google.android.material.chip.ChipGroup>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,7 @@
     <string name="course_meeting_fragment_chip_page_number">Seitenzahl</string>
     <string name="course_meeting_fragment_chip_own">eigene</string>
     <string name="course_meeting_fragment_chip_course_creator">Kursersteller</string>
+    <string name="course_meeting_fragment_chip_lecture_period">Vorlesungszeitraum</string>
     <string name="course_meeting_fragment_chip_exam">Prüfung</string>
     <string name="course_meeting_fragment_filter">Filter</string>
     <string name="course_meeting_fragment_sort">Sortierung</string>


### PR DESCRIPTION
#230 **Simultaneous Filtering**

As many filters as desired can now be selected. At the same time, of course, sorting is possible. 

The following has been tested several times: 

(1) different combinations of filters and sorting
(2) showing the full list after leaving and coming back
(3) impacting other meetings (should not)

**Additionally:**
Filtering by "answered" disables the "unanswered" filter and vice versa.

**Example:** Filter for "Organisation", "Others" and "own threads"

![filteroptionen](https://user-images.githubusercontent.com/41992838/161157646-c6cb6bff-dcce-4195-8a36-63f22da46535.png)

**#244 Filter threads by lecture period**
hide threads which are created before and after the meeting.

without filters:

![image](https://user-images.githubusercontent.com/41992838/161350432-c15d6859-cc07-46f0-a2b8-19b754b9d068.png)

filtered by lecture period (23:00 - 23:23, 1. April):

![image](https://user-images.githubusercontent.com/41992838/161350511-ed16cb0f-23df-42d0-8e4e-c7484bee9d87.png)


**#248 Sorting function for sorting meetings has been reduced to a method without switch and strings (filter options).**


**Additionally:**
**#230 Filtering by "answered" disables the "unanswered" filter and vice versa.**